### PR TITLE
fix(MixinItem): consumableComponent can sometimes be null

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinItem.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinItem.java
@@ -51,6 +51,8 @@ public class MixinItem {
             var itemStack = user.getStackInHand(hand);
             user.setCurrentHand(hand);
             ConsumableComponent consumableComponent = itemStack.get(DataComponentTypes.CONSUMABLE);
+            if (consumableComponent == null)
+                return;
             cir.setReturnValue(consumableComponent.consume(user, itemStack, hand));
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinItem.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinItem.java
@@ -51,8 +51,9 @@ public class MixinItem {
             var itemStack = user.getStackInHand(hand);
             user.setCurrentHand(hand);
             ConsumableComponent consumableComponent = itemStack.get(DataComponentTypes.CONSUMABLE);
-            if (consumableComponent == null)
+            if (consumableComponent == null) {
                 return;
+            }
             cir.setReturnValue(consumableComponent.consume(user, itemStack, hand));
         }
     }


### PR DESCRIPTION
Logs, if you want it: https://mclo.gs/k7P2nta
[Line 341](https://mclo.gs/k7P2nta#L341) was probably caused by me using Ctrl + Shift + F7 to switch to tty7 and then Ctrl + Shift + F1 to switch back to GDM since [it was lagging](https://mclo.gs/k7P2nta#L323) for some reason